### PR TITLE
Fix bug when server has no playlists

### DIFF
--- a/subsonic.py
+++ b/subsonic.py
@@ -355,7 +355,11 @@ async def get_user_playlists() -> list[int]:
             return None
         logger.debug("Playlists query response: %s", query_data)
 
-    playlists = query_data["subsonic-response"]["playlists"]["playlist"]
+    container = query_data["subsonic-response"]["playlists"]
+    if "playlist" in container:
+        playlists = container["playlist"]
+    else
+        playlists = None
 
     return playlists
 


### PR DESCRIPTION
Navidrome returns `"playlists":{{}}` instead of `"playlists":{"playlist":[]}` when there are no playlists, so this will cause an error to be thrown.