### PR TITLE
Use global application command registration if DISCORD_TEST_GUILD is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Then run the container with the environment variables described in the Configura
 | `SUBSONIC_PASSWORD` | Password or auth token for your Subsonic server | Yes |
 | `SUBSONIC_AUTH_MODE` | Authentication mode: `plaintext` or `token`. Token auth is highly recommended for security. | Yes |
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | Yes |
-| `DISCORD_TEST_GUILD` | Discord server ID where commands will be registered | Yes |
 | `DISCORD_OWNER_ID` | Your Discord user ID | Yes |
+| `DISCORD_TEST_GUILD` | Discord server ID where commands will be registered. Registers commands globally if not set. | No |
 | `BOT_STATUS` | Custom status message for the bot | No |
 | `BOT_PREFIX` | Command prefix for the bot. If unset, prefix commands can still be used with an @mention. An empty string will cause all messages to be interpreted as commands. | No |
 | `BOT_SEARCH_SUGGESTION_COUNT` | Number of items to display in the autocomplete menu. Defaults to 5. | No |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then run the container with the environment variables described in the Configura
 | `SUBSONIC_AUTH_MODE` | Authentication mode: `plaintext` or `token`. Token auth is highly recommended for security. | Yes |
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | Yes |
 | `DISCORD_OWNER_ID` | Your Discord user ID | Yes |
-| `DISCORD_TEST_GUILD` | Discord server ID where commands will be registered. Registers commands globally if not set. | No |
+| `DISCORD_TEST_GUILD` | Discord server ID where commands will be registered. If unset, commands will be registered globally. | No |
 | `BOT_STATUS` | Custom status message for the bot | No |
 | `BOT_PREFIX` | Command prefix for the bot. If unset, prefix commands can still be used with an @mention. An empty string will cause all messages to be interpreted as commands. | No |
 | `BOT_SEARCH_SUGGESTION_COUNT` | Number of items to display in the autocomplete menu. Defaults to 5. | No |

--- a/discodrome.py
+++ b/discodrome.py
@@ -55,9 +55,12 @@ class DiscodromeClient(commands.Bot):
     async def sync_command_tree(self) -> None:
         ''' Synchronizes the command tree with the guild used for testing. '''
 
-        guild = discord.Object(self.test_guild)
-        self.tree.copy_global_to(guild=guild)
-        await self.tree.sync(guild=guild)
+        if self.test_guild:
+            guild = discord.Object(self.test_guild)
+            self.tree.copy_global_to(guild=guild)
+            await self.tree.sync(guild=guild)
+        else:
+            await self.tree.sync()
 
     async def setup_hook(self) -> None:
         ''' Setup done after login, prior to events being dispatched. '''
@@ -68,8 +71,7 @@ class DiscodromeClient(commands.Bot):
         else:
             logger.error("Subsonic API is unreachable.")
 
-        if self.test_guild:
-            await self.sync_command_tree()
+        await self.sync_command_tree()
 
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.ensure_future(self._on_sigterm()))
@@ -96,4 +98,3 @@ if __name__ == "__main__":
     data.load_guild_properties_from_disk()
     client = DiscodromeClient(test_guild=env.DISCORD_TEST_GUILD)
     client.run(env.DISCORD_BOT_TOKEN, log_handler=None)
-


### PR DESCRIPTION
By default, this project requires `DISCORD_TEST_GUILD` to be set, and it will register the application commands (slash commands) to only the server with the ID that is set by `DISCORD_TEST_GUILD`. I believe this is not intuitive to people who are less familiar with the Discord API, so I have changed it to not require a test guild, and it will instead globally propagate commands to the bot itself, instead of just one server.

Since Discord has to cache the commands with this method, it may take some time for the commands to appear upon the first startup of the bot. Some people say it takes up to an hour, but I have never noticed it taking longer than 5 minutes. Just a quick refresh of the Discord client usually does the trick.